### PR TITLE
customize destination library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const empowerAssert = require('empower-assert');
 const acorn = require('acorn');
 const escodegen = require('escodegen');
 
-let source = 
+let source =
 `'use strict';
 const assert = require('assert');
 function add(a, b) {
@@ -42,13 +42,24 @@ console.log(escodegen.generate(transformed));
 //     assert.ok(!isNaN(b));
 //     return a + b;
 // }
+
+let transformedCustom = empowerAssert(acorn.parse(source), 'custom-lib');
+console.log(escodegen.generate(transformedCustom));
+// 'use strict';
+// const assert = require('custom-lib');
+// function add(a, b) {
+//     assert(!isNaN(a));
+//     assert.equal(typeof b, 'number');
+//     assert.ok(!isNaN(b));
+//     return a + b;
+// }
 ```
 
 ## License
 
 MIT License: Teppei Sato &lt;teppeis@gmail.com&gt;
 
-This is a port of [babel-plugin-empower-assert](https://github.com/power-assert-js/babel-plugin-empower-assert).  
+This is a port of [babel-plugin-empower-assert](https://github.com/power-assert-js/babel-plugin-empower-assert).
 Copyright (c) 2016 Takuto Wada, https://github.com/power-assert-js/babel-plugin-empower-assert
 
 [npm-image]: https://img.shields.io/npm/v/empower-assert.svg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "empower-assert",
   "description": "Convert assert to power-assert on ESTree AST",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "main": "index.js",
   "files": [

--- a/test/fixtures/assignment/expected-custom-lib.js
+++ b/test/fixtures/assignment/expected-custom-lib.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var assert;
+assert = require('custom-lib');
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/assignment_singlevar/expected-custom-lib.js
+++ b/test/fixtures/assignment_singlevar/expected-custom-lib.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var add, assert;
+assert = require('custom-lib');
+
+add = function (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+};

--- a/test/fixtures/commonjs/expected-custom-lib.js
+++ b/test/fixtures/commonjs/expected-custom-lib.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('custom-lib');
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_powerassert/expected-custom-lib.js
+++ b/test/fixtures/commonjs_powerassert/expected-custom-lib.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('power-assert');
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_singlevar/expected-custom-lib.js
+++ b/test/fixtures/commonjs_singlevar/expected-custom-lib.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var foo = 'FOO',
+    assert = require('custom-lib'),
+    bar = 'BAR';
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module/expected-custom-lib.js
+++ b/test/fixtures/es6module/expected-custom-lib.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'custom-lib';
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/es6module_powerassert/expected-custom-lib.js
+++ b/test/fixtures/es6module_powerassert/expected-custom-lib.js
@@ -1,0 +1,10 @@
+'use strict';
+
+import assert from 'power-assert';
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,8 @@ var espurify = require('espurify');
 var empowerAssert = require('../');
 
 function testTransform(fixtureName, extraOptions, extraSuffix) {
-  it(fixtureName, function() {
+  var specName = extraSuffix ? fixtureName + ' ' + extraSuffix : fixtureName;
+  it(specName, function() {
     var suffix = extraSuffix ? '-' + extraSuffix : '';
     var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
     var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected' + suffix + '.js');
@@ -19,7 +20,7 @@ function testTransform(fixtureName, extraOptions, extraSuffix) {
       sourceType: 'module'
     };
     var fixtureAst = acorn.parse(fixtureSource, parserOptions);
-    var actualAst = espurify(empowerAssert(fixtureAst));
+    var actualAst = espurify(empowerAssert(fixtureAst, extraSuffix));
     var expectedSource = fs.readFileSync(expectedFilepath).toString();
     var expectedAst = espurify(acorn.parse(expectedSource, parserOptions));
     assert.deepEqual(actualAst, expectedAst);
@@ -34,4 +35,11 @@ describe('empower-assert', function() {
   testTransform('assignment_singlevar');
   testTransform('es6module');
   testTransform('es6module_powerassert');
+  testTransform('commonjs', {}, 'custom-lib');
+  testTransform('commonjs_singlevar', {}, 'custom-lib');
+  testTransform('commonjs_powerassert', {}, 'custom-lib');
+  testTransform('assignment', {}, 'custom-lib');
+  testTransform('assignment_singlevar', {}, 'custom-lib');
+  testTransform('es6module', {}, 'custom-lib');
+  testTransform('es6module_powerassert', {}, 'custom-lib');
 });


### PR DESCRIPTION
Related to power-assert-js/power-assert#84. This module is the root of almost all `power-assert` instrumentors. So proposed changes needs to be propagated from there.