### PR TITLE
feat: support "Strict mode"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "4"
-  - "6"
-  - "7"
+  - "4" # to be removed on 2018-04-30
+  - "6" # to be removed on "April 2019"
+  - "8" # to be removed on "December 2019"
+  - "9" # to be removed on "June 2018"
 sudo: false
 cache:
   directories:

--- a/index.js
+++ b/index.js
@@ -47,13 +47,6 @@ function enter(node, parent) {
     if (!source || source.type !== Syntax.Literal || source.value !== 'assert') {
       return;
     }
-    var firstSpecifier = node.specifiers[0];
-    if (!firstSpecifier || firstSpecifier.type !== Syntax.ImportDefaultSpecifier) {
-      return;
-    }
-    if (!isIdentifier(firstSpecifier.local, 'assert')) {
-      return;
-    }
     changeAssertToPowerAssert(source);
   }
 }

--- a/index.js
+++ b/index.js
@@ -28,20 +28,18 @@ function enter(node, parent) {
     if (!isIdentifier(node.left, 'assert')) {
       return;
     }
-    if (!isRequireAssert(node.right)) {
+    if (replaceAssertIfMatch(node.right)) {
       return;
     }
-    changeAssertToPowerAssert(node.right.arguments[0]);
   }
 
   if (node.type === Syntax.VariableDeclarator) {
     if (!isIdentifier(node.id, 'assert')) {
       return;
     }
-    if (!isRequireAssert(node.init)) {
+    if (replaceAssertIfMatch(node.init)) {
       return;
     }
-    changeAssertToPowerAssert(node.init.arguments[0]);
   }
 
   if (node.type === Syntax.ImportDeclaration) {
@@ -58,6 +56,28 @@ function enter(node, parent) {
     }
     changeAssertToPowerAssert(source);
   }
+}
+
+/**
+ * @param {Object} node
+ * @return {boolean} true if `assert` is replaced to `power-assert`.
+ */
+function replaceAssertIfMatch(node) {
+  var target;
+  if (node === null) {
+    return false;
+  } else if (node.type === Syntax.CallExpression) {
+    target = node;
+  } else if (node.type === Syntax.MemberExpression) {
+    target = node.object;
+  } else {
+    return false;
+  }
+  if (isRequireAssert(target)) {
+    changeAssertToPowerAssert(target.arguments[0]);
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/test/fixtures/commonjs_singlevar_strictmode/expected.js
+++ b/test/fixtures/commonjs_singlevar_strictmode/expected.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var foo = 'FOO',
+    assert = require("power-assert").strict,
+    bar = 'BAR';
+
+function add(a, b) {
+  assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}

--- a/test/fixtures/commonjs_singlevar_strictmode/fixture.js
+++ b/test/fixtures/commonjs_singlevar_strictmode/fixture.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var foo = 'FOO',
+    assert = require('assert').strict,
+    bar = 'BAR';
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_strictmode/expected.js
+++ b/test/fixtures/commonjs_strictmode/expected.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('power-assert').strict;
+
+function add(a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/commonjs_strictmode/fixture.js
+++ b/test/fixtures/commonjs_strictmode/fixture.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var assert = require('assert').strict;
+
+function add (a, b) {
+    assert(!isNaN(a));
+    assert.equal(typeof b, 'number');
+    assert.ok(!isNaN(b));
+    return a + b;
+}

--- a/test/fixtures/esm_default_binding/expected.mjs
+++ b/test/fixtures/esm_default_binding/expected.mjs
@@ -1,0 +1,8 @@
+import assert from "power-assert";
+
+function add(a, b) {
+  assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}

--- a/test/fixtures/esm_default_binding/fixture.mjs
+++ b/test/fixtures/esm_default_binding/fixture.mjs
@@ -1,8 +1,6 @@
-'use strict';
+import assert from 'assert';
 
-import assert from 'power-assert';
-
-function add(a, b) {
+function add (a, b) {
     assert(!isNaN(a));
     assert.equal(typeof b, 'number');
     assert.ok(!isNaN(b));

--- a/test/fixtures/esm_default_binding_powerassert/expected.mjs
+++ b/test/fixtures/esm_default_binding_powerassert/expected.mjs
@@ -1,0 +1,8 @@
+import assert from 'power-assert';
+
+function add(a, b) {
+  assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}

--- a/test/fixtures/esm_default_binding_powerassert/fixture.mjs
+++ b/test/fixtures/esm_default_binding_powerassert/fixture.mjs
@@ -1,5 +1,3 @@
-'use strict';
-
 import assert from 'power-assert';
 
 function add (a, b) {

--- a/test/fixtures/esm_named_import_strictmode/expected.mjs
+++ b/test/fixtures/esm_named_import_strictmode/expected.mjs
@@ -1,0 +1,9 @@
+import { default as loose } from "power-assert";
+const assert = loose.strict;
+
+function add(a, b) {
+  assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}

--- a/test/fixtures/esm_named_import_strictmode/fixture.mjs
+++ b/test/fixtures/esm_named_import_strictmode/fixture.mjs
@@ -1,8 +1,7 @@
-'use strict';
+import { default as loose } from 'assert';
+const assert = loose.strict;
 
-import assert from 'power-assert';
-
-function add(a, b) {
+function add (a, b) {
     assert(!isNaN(a));
     assert.equal(typeof b, 'number');
     assert.ok(!isNaN(b));

--- a/test/fixtures/esm_namespace_import/expected.mjs
+++ b/test/fixtures/esm_namespace_import/expected.mjs
@@ -1,0 +1,8 @@
+import * as assert from "power-assert";
+
+function add(a, b) {
+  assert(!isNaN(a));
+  assert.equal(typeof b, 'number');
+  assert.ok(!isNaN(b));
+  return a + b;
+}

--- a/test/fixtures/esm_namespace_import/expected.mjs
+++ b/test/fixtures/esm_namespace_import/expected.mjs
@@ -1,4 +1,5 @@
-import * as assert from "power-assert";
+import * as ns from 'power-assert';
+const assert = ns.default;
 
 function add(a, b) {
   assert(!isNaN(a));

--- a/test/fixtures/esm_namespace_import/fixture.mjs
+++ b/test/fixtures/esm_namespace_import/fixture.mjs
@@ -1,6 +1,4 @@
-'use strict';
-
-import assert from 'assert';
+import * as assert from 'assert';
 
 function add (a, b) {
     assert(!isNaN(a));

--- a/test/fixtures/esm_namespace_import/fixture.mjs
+++ b/test/fixtures/esm_namespace_import/fixture.mjs
@@ -1,4 +1,5 @@
-import * as assert from 'assert';
+import * as ns from 'assert';
+const assert = ns.default;
 
 function add (a, b) {
     assert(!isNaN(a));

--- a/test/test.js
+++ b/test/test.js
@@ -7,11 +7,11 @@ var acorn = require('acorn');
 var espurify = require('espurify');
 var empowerAssert = require('../');
 
-function testTransform(fixtureName, extraOptions, extraSuffix) {
+function testTransform(fixtureName, extension) {
   it(fixtureName, function() {
-    var suffix = extraSuffix ? '-' + extraSuffix : '';
-    var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.js');
-    var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected' + suffix + '.js');
+    extension = extension || 'js';
+    var fixtureFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'fixture.' + extension);
+    var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.' + extension);
     var fixtureSource = fs.readFileSync(fixtureFilepath).toString();
     var parserOptions = {
       locations: true,
@@ -34,6 +34,8 @@ describe('empower-assert', function() {
   testTransform('commonjs_singlevar_strictmode');
   testTransform('assignment');
   testTransform('assignment_singlevar');
-  testTransform('es6module');
-  testTransform('es6module_powerassert');
+  testTransform('esm_default_binding', 'mjs');
+  testTransform('esm_default_binding_powerassert', 'mjs');
+  testTransform('esm_namespace_import', 'mjs');
+  testTransform('esm_named_import_strictmode', 'mjs');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,8 @@ describe('empower-assert', function() {
   testTransform('commonjs');
   testTransform('commonjs_singlevar');
   testTransform('commonjs_powerassert');
+  testTransform('commonjs_strictmode');
+  testTransform('commonjs_singlevar_strictmode');
   testTransform('assignment');
   testTransform('assignment_singlevar');
   testTransform('es6module');


### PR DESCRIPTION
Support ["strict mode"](https://nodejs.org/api/assert.html#assert_strict_mode) introduced in Node9

> When using the strict mode, any assert function will use the equality used in the strict function mode. So assert.deepEqual() will, for example, work the same as assert.deepStrictEqual().
> 
> ["Strict mode"](https://nodejs.org/api/assert.html#assert_strict_mode)
